### PR TITLE
Multi-threading fix for DetectorClocksServiceStandard

### DIFF
--- a/lardata/DetectorInfoServices/DetectorClocksServiceStandard.h
+++ b/lardata/DetectorInfoServices/DetectorClocksServiceStandard.h
@@ -122,6 +122,6 @@ namespace detinfo {
 
 DECLARE_ART_SERVICE_INTERFACE_IMPL(detinfo::DetectorClocksServiceStandard,
                                    detinfo::DetectorClocksService,
-                                   LEGACY)
+                                   SHARED)
 
 #endif // DETECTORCLOCKSSERVICESTANDARD_H


### PR DESCRIPTION
Don't forget to switch scope from LEGACY to SHARED.