### PR TITLE
Facilitate call to DetectorClocksStandard::DataFor() [2/2]

### DIFF
--- a/lardata/DetectorInfoServices/DetectorClocksServiceStandard.h
+++ b/lardata/DetectorInfoServices/DetectorClocksServiceStandard.h
@@ -96,24 +96,7 @@ namespace detinfo {
     }
 
     DetectorClocksData
-    DataFor(art::Event const& e) const override
-    {
-      auto const& config_values = fClocks.ConfigValues();
-      // Trigger times
-      double trig_time{config_values[kDefaultTrigTime]};
-      double beam_time{config_values[kDefaultBeamTime]};
-      if (auto times = trigger_times_for_event(fClocks.TrigModuleName(), e)) {
-        std::tie(trig_time, beam_time) = *times;
-      }
-
-      double g4_ref_time{config_values[kG4RefTime]};
-      if (auto sim_trig_time = g4ref_time_for_event(fClocks.G4RefCorrTrigModuleName(), e)) {
-        g4_ref_time -= trig_time;
-        g4_ref_time += *sim_trig_time;
-      }
-
-      return fClocks.DataFor(g4_ref_time, trig_time, beam_time);
-    }
+    DataFor(art::Event const& e) const override;
 
     DetectorClocksStandard fClocks;
     bool fInheritClockConfig;
@@ -125,3 +108,4 @@ DECLARE_ART_SERVICE_INTERFACE_IMPL(detinfo::DetectorClocksServiceStandard,
                                    SHARED)
 
 #endif // DETECTORCLOCKSSERVICESTANDARD_H
+

--- a/lardata/DetectorInfoServices/DetectorClocksServiceStandard_service.cc
+++ b/lardata/DetectorInfoServices/DetectorClocksServiceStandard_service.cc
@@ -16,7 +16,7 @@
 #include "fhiclcpp/make_ParameterSet.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataalg/DetectorInfo/DetectorClocksStandard.h"
-#include "lardataalg/DetectorInfo/DetectorClocksStandardTriggerLoader.h"
+#include "lardataalg/DetectorInfo/DetectorClocksStandardDataFor.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -121,7 +121,13 @@ namespace detinfo {
       fClocks.SetConfigValue(i, config_value[i]);
     }
     fClocks.ApplyParams();
-  }
+  } // DetectorClocksServiceStandard::postOpenFile()
+  
+  
+  DetectorClocksData DetectorClocksServiceStandard::DataFor
+    (art::Event const& e) const
+    { return detinfo::detectorClocksStandardDataFor(fClocks, e); }
+  
 
 } // namespace detinfo
 


### PR DESCRIPTION
This is part of a group of pull requests that also include pull request LArSoft/lardataalg#16.

The explanation and details of this request are stated in that pull request.
Please keep the discussion on the general design of the feature in there.