### PR TITLE
Releasing memory after a SQL query

### DIFF
--- a/lardata/DetectorInfoServices/DetectorClocksServiceStandard_service.cc
+++ b/lardata/DetectorInfoServices/DetectorClocksServiceStandard_service.cc
@@ -110,6 +110,7 @@ namespace detinfo {
 
         count_configuration_changes(ps);
       }
+      sqlite3_finalize(stmt);
     }
 
     for (size_t i = 0; i < kConfigTypeMax; ++i) {


### PR DESCRIPTION
A memory black hole was reported in [Redmine issue #26029](https://cdcvs.fnal.gov/redmine/issues/26036).
It turns out to be a memory leak because of a ["grievous error for the application"](https://sqlite.org/c3ref/finalize.html).

This commit should resolve [said Redmine issue #26029](https://cdcvs.fnal.gov/redmine/issues/26036).