### PR TITLE
Added dumper for `recob::OpHit` and `recob::OpFlash` [1/2]

### DIFF
--- a/lardata/ArtDataHelper/Dumpers/CMakeLists.txt
+++ b/lardata/ArtDataHelper/Dumpers/CMakeLists.txt
@@ -7,6 +7,7 @@ set(RawDataDumpers
   "DumpOpDetWaveforms")
 set(RecoBaseDumpers
   "DumpWires"
+  "DumpOpHits"
   "DumpHits"
   "DumpClusters"
   "DumpSeeds"

--- a/lardata/ArtDataHelper/Dumpers/CMakeLists.txt
+++ b/lardata/ArtDataHelper/Dumpers/CMakeLists.txt
@@ -8,6 +8,7 @@ set(RawDataDumpers
 set(RecoBaseDumpers
   "DumpWires"
   "DumpOpHits"
+  "DumpOpFlashes"
   "DumpHits"
   "DumpClusters"
   "DumpSeeds"

--- a/lardata/ArtDataHelper/Dumpers/DumpOpFlashes_module.cc
+++ b/lardata/ArtDataHelper/Dumpers/DumpOpFlashes_module.cc
@@ -1,0 +1,253 @@
+/**
+ * @file   DumpOpFlashes_module.cc
+ * @brief  Dumps on screen the content of the reconstructed optical flashes.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 20, 2023
+ */
+
+// LArSoft libraries
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "larcorealg/CoreUtils/values.h"
+#include "lardataobj/RecoBase/OpFlash.h"
+#include "lardataobj/RecoBase/OpHit.h"
+
+// art libraries
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Utilities/InputTag.h"
+
+// support libraries
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Comment.h"
+#include "fhiclcpp/types/Name.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// C//C++ standard libraries
+#include <cassert>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// -----------------------------------------------------------------------------
+namespace ophit {
+  class DumpOpFlashes;
+}
+
+/**
+ * @brief Prints the content of all the flashes on screen
+ *
+ * This analyser prints the content of all the flashes into the
+ * `LogInfo`/`LogVerbatim` stream.
+ *
+ *
+ * Configuration parameters
+ * =========================
+ *
+ * * **OpFlashModuleLabel** (input tag): tag of the `recob::OpFlash` collection
+ *    data product to be dumped.
+ * * **PrintOpHitAssociations** (flag, default: `true`): also print a list of
+ *    optical hits associated to each flash.
+ * * **OutputCategory** (string, default: `"DumpOpFlashes"`): the category
+ *   used for the output (useful for filtering).
+ *
+ *
+ * Input data products
+ * ====================
+ *
+ * * `std::vector<recob::OpFlash>` (`OpFlashModuleLabel`): the flash collection
+ *     being dumped
+ * * `art::Assns<recob::OpFlash, recob::OpHit>` (`OpFlashModuleLabel`): the
+ *     associated optical hits. The index of each hit will be printed.
+ *     In addition, if the optical hit data product is available, it will be
+ *     fully read and channel, start time and p.e. of the hits will be printed.
+ *
+ */
+class ophit::DumpOpFlashes : public art::EDAnalyzer {
+public:
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+
+    fhicl::Atom<art::InputTag> OpFlashModuleLabel{
+      Name{"OpFlashModuleLabel"},
+      Comment{"tag of the recob::OpFlash collection to be dumped"}};
+
+    fhicl::Atom<bool> PrintOpHitAssociations{
+      Name("PrintOpHitAssociations"),
+      Comment("also prints a list of optical hits associated to the flash"),
+      true};
+
+    fhicl::Atom<std::string> OutputCategory{
+      Name("OutputCategory"),
+      Comment("the messagefacility category used for the output"),
+      "DumpOpFlashes"};
+
+  }; // Config
+
+  using Parameters = art::EDAnalyzer::Table<Config>;
+
+  /// Default constructor
+  explicit DumpOpFlashes(Parameters const& config);
+
+  /// Does the printing
+  void analyze(const art::Event& evt) override;
+
+private:
+  art::InputTag const fOpFlashModuleTag; ///< Optical hit data product tag.
+  bool const fPrintOpHitAssociations;    ///< Whether to print optical hits.
+  std::string const fOutputCategory;     ///< Category for `mf::LogInfo` output.
+
+}; // class ophit::DumpOpFlashes
+
+// -----------------------------------------------------------------------------
+// ---  implementation
+// -----------------------------------------------------------------------------
+namespace {
+
+  struct ProductSourceEntry_t {
+    std::size_t index = 0;                        ///< An incremental index.
+    art::BranchDescription const* info = nullptr; ///< Pointer to the product information.
+  };
+  using ProductSourceDirectory_t = std::unordered_map<art::ProductID, ProductSourceEntry_t>;
+
+  /**
+   * @brief Returns a map from product ID to product information for all
+   *        pointers on one side of an association.
+   * @tparam Side which side of the association (either `0` or `1`)
+   * @tparam Assns the type of association
+   * @tparam Event the type of event (makes this code gallery-compatible)
+   * @param assns the association to be parsed
+   * @param event the event holding the information
+   * @return a map from product ID to product information
+   *
+   * The product information is a pair:
+   *  * `first`: an incremental index
+   *  * `second`: a pointer to the product information (_art_ branch description)
+   */
+  template <std::size_t Side = 1U, typename Assns, typename Event>
+  ProductSourceDirectory_t buildAssnsSourceDirectory(Assns const& assns, Event const& event)
+  {
+
+    ProductSourceDirectory_t dir;
+
+    // extract all the unique IDs
+    for (auto const& ptrs : assns)
+      dir.emplace(std::get<Side>(ptrs).id(), ProductSourceEntry_t{});
+
+    // assign the index and pointer to each entry (order is not defined)
+    std::size_t index{0};
+    for (auto& [id, info] : dir)
+      info = {index++, event.getProductDescription(id).get()};
+
+    return dir;
+  } // buildAssnsSourceDirectory()
+
+  //----------------------------------------------------------------------------
+  template <typename Stream>
+  void dumpAssociatedOpHits(Stream& out,
+                            std::vector<art::Ptr<recob::OpHit>> const& hits,
+                            ProductSourceDirectory_t const* sourceMap = nullptr,
+                            std::string const& indent = "",
+                            int const itemsPerLine = 18)
+  {
+    out << hits.size() << " hits associated:";
+    int itemsLeft = 0;
+    const bool bPrintSources = sourceMap && (sourceMap->size() >= 2);
+    for (art::Ptr<recob::OpHit> const& hitPtr : hits) {
+      if (itemsLeft-- <= 0) {
+        itemsLeft += itemsPerLine;
+        out << "\n" << indent;
+      }
+
+      out << "  [";
+      if (bPrintSources) out << "S#" << sourceMap->at(hitPtr.id()).index << ";";
+      out << "#" << hitPtr.key() << "]";
+      if (!hitPtr.isAvailable()) continue;
+
+      itemsLeft -= 5; // full hit information is equivalent to 6 "items"
+
+      recob::OpHit const& hit = *hitPtr;
+      out << " ch=" << hit.OpChannel();
+      if (hit.HasStartTime())
+        out << " time=" << hit.StartTime();
+      else
+        out << " peak time=" << hit.PeakTime();
+      out << " p.e.=" << hit.PE();
+
+    } // for hits
+  }   // dumpAssociatedHits()
+
+  //----------------------------------------------------------------------------
+
+} // local namespace
+
+// -----------------------------------------------------------------------------
+ophit::DumpOpFlashes::DumpOpFlashes(Parameters const& config)
+  : art::EDAnalyzer(config)
+  , fOpFlashModuleTag(config().OpFlashModuleLabel())
+  , fPrintOpHitAssociations(config().PrintOpHitAssociations())
+  , fOutputCategory(config().OutputCategory())
+{
+  consumes<std::vector<recob::OpFlash>>(fOpFlashModuleTag);
+  if (fPrintOpHitAssociations)
+    consumes<art::Assns<recob::OpFlash, recob::OpHit>>(fOpFlashModuleTag);
+}
+
+//------------------------------------------------------------------------------
+void ophit::DumpOpFlashes::analyze(art::Event const& event)
+{
+
+  // fetch the data to be dumped on screen
+  auto const& OpFlashHandle = event.getValidHandle<std::vector<recob::OpFlash>>(fOpFlashModuleTag);
+
+  mf::LogVerbatim(fOutputCategory)
+    << "Event " << event.id() << " contains " << OpFlashHandle->size() << " '"
+    << fOpFlashModuleTag.encode() << "' optical flashes.";
+
+  std::optional const flashHits =
+    fPrintOpHitAssociations ?
+      std::make_optional<art::FindManyP<recob::OpHit>>(OpFlashHandle, event, fOpFlashModuleTag) :
+      std::nullopt;
+  ProductSourceDirectory_t const sourceMap =
+    fPrintOpHitAssociations ?
+      buildAssnsSourceDirectory<1>(
+        event.getProduct<art::Assns<recob::OpFlash, recob::OpHit>>(fOpFlashModuleTag), event) :
+      ProductSourceDirectory_t{};
+  assert(!fPrintOpHitAssociations || (flashHits->size() == 0) || !sourceMap.empty());
+
+  for (auto const& [iFlash, flash] : util::enumerate(*OpFlashHandle)) {
+
+    mf::LogVerbatim out{fOutputCategory};
+    out << "OpFlash #" << iFlash << ": " << flash;
+
+    if (flashHits) {
+      out << "\n  ";
+      dumpAssociatedOpHits(out, flashHits->at(iFlash), &sourceMap, "  ");
+    }
+
+  } // for flashes
+
+  if (sourceMap.size() > 1) {
+    mf::LogVerbatim out{fOutputCategory};
+    out << "Hits were from " << sourceMap.size() << " data products (SRC):";
+    for (auto const& [index, info] : util::values(sourceMap))
+      out << "  [S#" << index << "]  '" << info->inputTag().encode() << "'";
+    out << ".";
+  }
+  else if (sourceMap.size() == 1) {
+    mf::LogVerbatim{fOutputCategory} << "All hits were from the data product '"
+                                     << sourceMap.begin()->second.info->inputTag().encode() << "'.";
+  }
+
+} // ophit::DumpOpFlashes::analyze()
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(ophit::DumpOpFlashes)
+
+//------------------------------------------------------------------------------

--- a/lardata/ArtDataHelper/Dumpers/DumpOpHits_module.cc
+++ b/lardata/ArtDataHelper/Dumpers/DumpOpHits_module.cc
@@ -75,8 +75,8 @@ public:
   void analyze(const art::Event& evt) override;
 
 private:
-  art::InputTag const fOpHitsModuleTag; ///< Optical hit data product tag.
-  std::string const fOutputCategory;    ///< Category for `mf::LogInfo` output.
+  art::InputTag const fOpHitModuleTag; ///< Optical hit data product tag.
+  std::string const fOutputCategory;   ///< Category for `mf::LogInfo` output.
 
 }; // class ophit::DumpOpHits
 
@@ -101,19 +101,21 @@ std::ostream& recob::operator<<(std::ostream& out, recob::OpHit const& hit)
 // -----------------------------------------------------------------------------
 ophit::DumpOpHits::DumpOpHits(Parameters const& config)
   : art::EDAnalyzer(config)
-  , fOpHitsModuleTag(config().OpHitModuleLabel())
+  , fOpHitModuleTag(config().OpHitModuleLabel())
   , fOutputCategory(config().OutputCategory())
-{}
+{
+  consumes<std::vector<recob::OpHit>>(fOpHitModuleTag);
+}
 
 //------------------------------------------------------------------------------
 void ophit::DumpOpHits::analyze(art::Event const& event)
 {
 
   // fetch the data to be dumped on screen
-  auto const& OpHits = event.getProduct<std::vector<recob::OpHit>>(fOpHitsModuleTag);
+  auto const& OpHits = event.getProduct<std::vector<recob::OpHit>>(fOpHitModuleTag);
 
   mf::LogVerbatim(fOutputCategory) << "Event " << event.id() << " contains " << OpHits.size()
-                                   << " '" << fOpHitsModuleTag.encode() << "' optical hits.";
+                                   << " '" << fOpHitModuleTag.encode() << "' optical hits.";
 
   for (auto const& [iHit, hit] : util::enumerate(OpHits))
     mf::LogVerbatim(fOutputCategory) << "OpHit #" << iHit << ": " << hit;

--- a/lardata/ArtDataHelper/Dumpers/DumpOpHits_module.cc
+++ b/lardata/ArtDataHelper/Dumpers/DumpOpHits_module.cc
@@ -27,9 +27,6 @@
 #include <vector>
 
 // -----------------------------------------------------------------------------
-namespace recob {
-  std::ostream& operator<<(std::ostream& out, recob::OpHit const& hit);
-}
 namespace ophit {
   class DumpOpHits;
 }
@@ -82,22 +79,6 @@ private:
 
 // -----------------------------------------------------------------------------
 // ---  implementation
-// -----------------------------------------------------------------------------
-std::ostream& recob::operator<<(std::ostream& out, recob::OpHit const& hit)
-{
-  // single line output
-
-  out << "Hit on optical channel " << hit.OpChannel();
-  if (hit.HasStartTime()) out << " starting at " << hit.StartTime();
-  out << " us, peak at " << hit.PeakTime() << " us (absolute: " << hit.PeakTimeAbs() << " us)";
-  if (hit.RiseTime() > 0.0) out << "; rise time: " << hit.RiseTime() << " us";
-  out << "; width " << hit.Width() << " us, amplitude " << hit.Amplitude() << " ADC#, integral "
-      << hit.Area() << " ADC#, " << hit.PE() << " photoelectrons";
-  if (hit.FastToTotal() > 0.0) out << "; fast fraction: " << hit.FastToTotal();
-
-  return out;
-} // recob::operator<< (std::ostream&, recob::OpHit const&)
-
 // -----------------------------------------------------------------------------
 ophit::DumpOpHits::DumpOpHits(Parameters const& config)
   : art::EDAnalyzer(config)

--- a/lardata/ArtDataHelper/Dumpers/DumpOpHits_module.cc
+++ b/lardata/ArtDataHelper/Dumpers/DumpOpHits_module.cc
@@ -1,0 +1,126 @@
+/**
+ * @file   DumpOpHits_module.cc
+ * @brief  Dumps on screen the content of the reconstructed optical hits.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 10, 2023
+ */
+
+// LArSoft libraries
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "lardataobj/RecoBase/OpHit.h"
+
+// art libraries
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "canvas/Utilities/InputTag.h"
+
+// support libraries
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Comment.h"
+#include "fhiclcpp/types/Name.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// C//C++ standard libraries
+#include <ostream>
+#include <string>
+#include <vector>
+
+// -----------------------------------------------------------------------------
+namespace recob {
+  std::ostream& operator<<(std::ostream& out, recob::OpHit const& hit);
+}
+namespace ophit {
+  class DumpOpHits;
+}
+
+/**
+ * @brief Prints the content of all the hits on screen
+ *
+ * This analyser prints the content of all the hits into the
+ * `LogInfo`/`LogVerbatim` stream.
+ *
+ * Configuration parameters
+ * =========================
+ *
+ * * **OpHitModuleLabel** (input tag): tag of the `recob::OpHit` collection data
+ *    product to be dumped.
+ * * **OutputCategory** (string, default: `"DumpOpHits"`): the category
+ *   used for the output (useful for filtering).
+ *
+ */
+class ophit::DumpOpHits : public art::EDAnalyzer {
+public:
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+
+    fhicl::Atom<art::InputTag> OpHitModuleLabel{
+      Name{"OpHitModuleLabel"},
+      Comment{"tag of the recob::OpHit collection to be dumped"}};
+
+    fhicl::Atom<std::string> OutputCategory{
+      Name("OutputCategory"),
+      Comment("the messagefacility category used for the output"),
+      "DumpOpHits"};
+
+  }; // Config
+
+  using Parameters = art::EDAnalyzer::Table<Config>;
+
+  /// Default constructor
+  explicit DumpOpHits(Parameters const& config);
+
+  /// Does the printing
+  void analyze(const art::Event& evt) override;
+
+private:
+  art::InputTag const fOpHitsModuleTag; ///< Optical hit data product tag.
+  std::string const fOutputCategory;    ///< Category for `mf::LogInfo` output.
+
+}; // class ophit::DumpOpHits
+
+// -----------------------------------------------------------------------------
+// ---  implementation
+// -----------------------------------------------------------------------------
+std::ostream& recob::operator<<(std::ostream& out, recob::OpHit const& hit)
+{
+  // single line output
+
+  out << "Hit on optical channel " << hit.OpChannel();
+  if (hit.HasStartTime()) out << " starting at " << hit.StartTime();
+  out << " us, peak at " << hit.PeakTime() << " us (absolute: " << hit.PeakTimeAbs() << " us)";
+  if (hit.RiseTime() > 0.0) out << "; rise time: " << hit.RiseTime() << " us";
+  out << "; width " << hit.Width() << " us, amplitude " << hit.Amplitude() << " ADC#, integral "
+      << hit.Area() << " ADC#, " << hit.PE() << " photoelectrons";
+  if (hit.FastToTotal() > 0.0) out << "; fast fraction: " << hit.FastToTotal();
+
+  return out;
+} // recob::operator<< (std::ostream&, recob::OpHit const&)
+
+// -----------------------------------------------------------------------------
+ophit::DumpOpHits::DumpOpHits(Parameters const& config)
+  : art::EDAnalyzer(config)
+  , fOpHitsModuleTag(config().OpHitModuleLabel())
+  , fOutputCategory(config().OutputCategory())
+{}
+
+//------------------------------------------------------------------------------
+void ophit::DumpOpHits::analyze(art::Event const& event)
+{
+
+  // fetch the data to be dumped on screen
+  auto const& OpHits = event.getProduct<std::vector<recob::OpHit>>(fOpHitsModuleTag);
+
+  mf::LogVerbatim(fOutputCategory) << "Event " << event.id() << " contains " << OpHits.size()
+                                   << " '" << fOpHitsModuleTag.encode() << "' optical hits.";
+
+  for (auto const& [iHit, hit] : util::enumerate(OpHits))
+    mf::LogVerbatim(fOutputCategory) << "OpHit #" << iHit << ": " << hit;
+
+} // ophit::DumpOpHits::analyze()
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(ophit::DumpOpHits)
+
+//------------------------------------------------------------------------------

--- a/lardata/ArtDataHelper/Dumpers/dump_opflashes.fcl
+++ b/lardata/ArtDataHelper/Dumpers/dump_opflashes.fcl
@@ -1,0 +1,64 @@
+#
+# File:     dump_opflashes.fcl
+# Purpose:  Dump on screen optical flash content
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     February 20, 2023
+# Version:  1.0
+#
+# Service dependencies:
+# - message facility
+#
+
+process_name: DumpOpFlashes
+
+services: {
+  
+  message: {
+    destinations: {
+      
+      # grab all the "DumpOpFlashes" messages and put them in DumpOpFlashes.log
+      DumpOpFlashes: {
+        append: false
+        categories: {
+          DumpOpFlashes: { limit: -1 }
+          default: { limit: 0 }
+        }
+        filename: "DumpOpFlashes.log"
+        threshold: "INFO"
+        type: "file"
+      } # DumpOpFlashes
+      
+      LogStandardOut: {
+        categories: {
+          DumpOpFlashes: { limit: 0 }
+          default: {}
+        }
+        threshold: "WARNING"
+        type: "cout"
+      } # LogStandardOut
+      
+    } # destinations
+  } # message
+} # services
+
+
+physics: {
+  analyzers: {
+    dumpopflashes: {
+      module_type:  DumpOpFlashes
+      
+      # specify the tag of the recob::OpFlash producer
+      OpFlashModuleLabel:  "opflash"
+      
+      # do print associated optical hit information
+      PrintOpHitAssociations: true
+      
+      # output category ("DumpOpFlashes" by default), useful for filtering (see above)
+      OutputCategory: "DumpOpFlashes"
+      
+    } # dumpopflashes
+  } # analyzers
+  
+  ana: [ dumpopflashes ]
+  
+} # physics

--- a/lardata/ArtDataHelper/Dumpers/dump_ophits.fcl
+++ b/lardata/ArtDataHelper/Dumpers/dump_ophits.fcl
@@ -1,5 +1,5 @@
 #
-# File:     dumpophits.fcl
+# File:     dump_ophits.fcl
 # Purpose:  Dump on screen optical hit content
 # Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
 # Date:     February 10, 2023

--- a/lardata/ArtDataHelper/Dumpers/dumpophits.fcl
+++ b/lardata/ArtDataHelper/Dumpers/dumpophits.fcl
@@ -1,0 +1,61 @@
+#
+# File:     dumpophits.fcl
+# Purpose:  Dump on screen optical hit content
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     February 10, 2023
+# Version:  1.0
+#
+# Service dependencies:
+# - message facility
+#
+
+process_name: DumpOpHits
+
+services: {
+  
+  message: {
+    destinations: {
+      
+      # grab all the "DumpOpHits" messages and put them in DumpOpHits.log
+      DumpOpHits: {
+        append: false
+        categories: {
+          DumpOpHits: { limit: -1 }
+          default: { limit: 0 }
+        }
+        filename: "DumpOpHits.log"
+        threshold: "INFO"
+        type: "file"
+      } # DumpOpHits
+      
+      LogStandardOut: {
+        categories: {
+          DumpOpHits: { limit: 0 }
+          default: {}
+        }
+        threshold: "WARNING"
+        type: "cout"
+      } # LogStandardOut
+      
+    } # destinations
+  } # message
+} # services
+
+
+physics: {
+  analyzers: {
+    dumpophits: {
+      module_type:  DumpOpHits
+      
+      # specify the tag of the recob::OpHit producer
+      OpHitModuleLabel:  "ophit"
+      
+      # output category ("DumpOpHits" by default), useful for filtering (see above)
+      OutputCategory: "DumpOpHits"
+      
+    } # dumpophits
+  } # analyzers
+  
+  ana: [ dumpophits ]
+  
+} # physics


### PR DESCRIPTION
While working at LArSoft/larana#25, I realised that there is no dumper for `recob::OpHit` data products yet.
The simple module in the pull request tries to fill the gap. (There is none for `recob::OpFlash` either, but right now I am not filling _that_ gap.)

There is the question whether it is preferred for an `operator<< (std::ostream&, recob::OpHit const&)`  to be defined in the data product library (in `lardataobj`, like for the most part of TPC reconstruction classes) instead.

The updated pull request also adds a new dumper for `recob::OpFlash`.
Because of the insertion operator change recommended by LArSoft, this request is now paired to LArSoft/lardataobj#35.
